### PR TITLE
fix: resolve code review comments

### DIFF
--- a/apps/websocket-service-nest/src/chat/chat.gateway.ts
+++ b/apps/websocket-service-nest/src/chat/chat.gateway.ts
@@ -218,7 +218,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
           isAuthenticated: client.data.isAuthenticated,
           user: client.data.user,
           conversationNumber: 1,
-          status: 'active',
+          status: CaseStatus.ACTIVE,
           title: 'Nova Conversa #1',
         });
 


### PR DESCRIPTION
- Use CaseStatus.ACTIVE enum instead of hardcoded 'active' string in chat.gateway.ts
- Verified AI_ALLOWED_STATUSES constant is properly used in message.service.ts
- Confirmed comment consistency in Conversation.ts model
- No console.log at module level found in Chat.tsx (may have been removed)

All code review comments have been addressed for production readiness.